### PR TITLE
Add Caddy reverse proxy and static frontend folder

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+baseUrlPath = "streamlit"
+port = 8501
+address = "0.0.0.0"

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+:80 {
+    # Serve static files from the /static directory at the root
+    root * /srv
+    file_server
+
+    # Reverse proxy requests to /streamlit to the streamlit service
+    handle /streamlit* {
+        reverse_proxy streamlit:8501
+    }
+
+    # Logging
+    log {
+        output stdout
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
       context: .
       dockerfile: Dockerfile.streamlit
     restart: always
-    ports:
-      - "9102:8501"
     environment:
       - DB_CONN=prod
     depends_on:
@@ -32,6 +30,17 @@ services:
       - '9202:5432'
     volumes:
       - db:/var/lib/postgresql/data
+
+  caddy:
+    image: caddy:latest
+    restart: always
+    ports:
+      - "9102:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./static:/srv
+    depends_on:
+      - streamlit
 volumes:
   db:
     driver: local

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vehicle Positions</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/4.1.3/maplibre-gl.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/maplibre-gl/4.1.3/maplibre-gl.min.css" />
+  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { width: 100%; height: 100%; overflow: hidden; background: #1a1a2e; font-family: system-ui, sans-serif; }
+    #map { width: 100%; height: 100%; }
+
+    #hud {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      background: rgba(15, 15, 30, 0.88);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      padding: 12px 16px;
+      color: #e0e0f0;
+      font-size: 13px;
+      min-width: 180px;
+      backdrop-filter: blur(6px);
+      pointer-events: none;
+    }
+    #hud h2 { font-size: 14px; font-weight: 600; margin-bottom: 8px; color: #a0c4ff; letter-spacing: 0.04em; }
+    #hud .stat { display: flex; justify-content: space-between; gap: 24px; margin-bottom: 4px; }
+    #hud .stat span:last-child { color: #fff; font-weight: 600; }
+    #hud .updated { margin-top: 8px; font-size: 11px; color: #888; }
+
+    #tooltip {
+      position: absolute;
+      pointer-events: none;
+      background: rgba(15, 15, 30, 0.92);
+      border: 1px solid rgba(160, 196, 255, 0.3);
+      border-radius: 8px;
+      padding: 10px 14px;
+      color: #e0e0f0;
+      font-size: 13px;
+      display: none;
+      max-width: 240px;
+      backdrop-filter: blur(6px);
+    }
+    #tooltip .tline { font-size: 18px; font-weight: 700; color: #a0c4ff; margin-bottom: 4px; }
+    #tooltip .trow { margin: 2px 0; font-size: 12px; color: #aaa; }
+    #tooltip .trow span { color: #e0e0f0; }
+
+    #controls {
+      position: absolute;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 10px;
+    }
+    #controls button {
+      background: rgba(15,15,30,0.88);
+      border: 1px solid rgba(255,255,255,0.15);
+      border-radius: 8px;
+      color: #a0c4ff;
+      font-size: 13px;
+      padding: 8px 18px;
+      cursor: pointer;
+      backdrop-filter: blur(6px);
+      transition: background 0.2s;
+    }
+    #controls button:hover { background: rgba(40,40,80,0.95); }
+    #controls button.active { background: rgba(60,80,160,0.9); color: #fff; border-color: #a0c4ff; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <div id="hud">
+    <h2>🚌 Vehicle Positions</h2>
+    <div class="stat"><span>Vehicles</span><span id="stat-count">—</span></div>
+    <div class="stat"><span>Lines</span><span id="stat-lines">—</span></div>
+    <div class="updated" id="stat-time">Loading…</div>
+  </div>
+
+  <div id="tooltip"></div>
+
+  <div id="controls">
+    <button id="btn-refresh" onclick="loadData()">⟳ Refresh</button>
+    <button id="btn-auto" class="active" onclick="toggleAuto()">⏸ Auto (3s)</button>
+  </div>
+
+  <script>
+    let data = [];
+
+    const GEOJSON_URL = "https://toolsapi.knuthp.no/data/entur_et/positions_interpolated.geojson";
+    const REFRESH_INTERVAL = 3000;
+
+    // --- SVG icon atlas ---
+    // We render icons onto a canvas to create a sprite atlas for IconLayer
+    const ICON_SIZE = 64;
+    const ICONS = { bus: drawBusIcon };
+
+    function drawBusIcon(ctx, x, y, size) {
+      const s = size, h = s, w = s * 0.7;
+      const ox = x + (size - w) / 2, oy = y + (size - h) / 2;
+      ctx.fillStyle = "#3a86ff";
+      roundRect(ctx, ox, oy, w, h * 0.72, 6);
+      ctx.fill();
+      // windshield
+      ctx.fillStyle = "rgba(180,220,255,0.85)";
+      roundRect(ctx, ox + w * 0.1, oy + h * 0.06, w * 0.8, h * 0.22, 3);
+      ctx.fill();
+      // wheels
+      ctx.fillStyle = "#1a1a2e";
+      [[ox + w * 0.18, oy + h * 0.72], [ox + w * 0.62, oy + h * 0.72]].forEach(([cx, cy]) => {
+        ctx.beginPath();
+        ctx.arc(cx + w * 0.1, cy + h * 0.04, w * 0.13, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = "#3a86ff";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      });
+    }
+
+    function roundRect(ctx, x, y, w, h, r) {
+      ctx.beginPath();
+      ctx.moveTo(x + r, y);
+      ctx.lineTo(x + w - r, y);
+      ctx.arcTo(x + w, y, x + w, y + r, r);
+      ctx.lineTo(x + w, y + h - r);
+      ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+      ctx.lineTo(x + r, y + h);
+      ctx.arcTo(x, y + h, x, y + h - r, r);
+      ctx.lineTo(x, y + r);
+      ctx.arcTo(x, y, x + r, y, r);
+      ctx.closePath();
+    }
+
+    function buildIconAtlas() {
+      const canvas = document.createElement("canvas");
+      canvas.width = ICON_SIZE;
+      canvas.height = ICON_SIZE;
+      const ctx = canvas.getContext("2d");
+      drawBusIcon(ctx, 0, 0, ICON_SIZE);
+      return {
+        url: canvas.toDataURL(),
+        mapping: {
+          bus: { x: 0, y: 0, width: ICON_SIZE, height: ICON_SIZE, anchorY: ICON_SIZE }
+        }
+      };
+    }
+
+    const iconAtlas = buildIconAtlas();
+
+    // --- MapLibre setup ---
+    const map = new maplibregl.Map({
+      container: "map",
+      style: {
+        version: 8,
+        sources: {
+          osm: {
+            type: "raster",
+            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+            tileSize: 256,
+            attribution: "© OpenStreetMap contributors"
+          }
+        },
+        layers: [{ id: "osm", type: "raster", source: "osm" }]
+      },
+      center: [10.75, 59.91],  // Oslo
+      zoom: 10,
+      attributionControl: { compact: true }
+    });
+
+    // --- deck.gl overlay ---
+    const deckOverlay = new deck.MapboxOverlay({ layers: [] });
+    map.addControl(deckOverlay);
+
+    // --- State ---
+    let autoTimer = setInterval(loadData, REFRESH_INTERVAL);;
+
+    // --- Load GeoJSON ---
+    async function loadData() {
+      const btn = document.getElementById("btn-refresh");
+      btn.textContent = "⟳ Loading…";
+      try {
+        const res = await fetch(GEOJSON_URL + "?t=" + Date.now());
+        if (!res.ok) throw new Error(res.statusText);
+        const geojson = await res.json();
+        data = geojson.features.map(f => ({
+          coordinates: f.geometry.coordinates,
+          journey_ref: f.properties.journey_ref,
+          line_ref: f.properties.line_ref,
+          time_diff_seconds: f.properties.time_diff_seconds,
+          line_name: f.properties.line_name,
+          status: f.properties.status,
+          vehicle_ref: f.properties.vehicle_ref,
+          stop_name: f.properties.stop_name,
+          next_stop_name: f.properties.next_stop_name,
+          estimated_at: f.properties.estimated_at,
+          progress: f.properties.progress,
+          mode: f.properties.mode || "bus"
+        }));
+        render();
+        updateHud();
+      } catch (e) {
+        console.error("Failed to load positions:", e);
+        document.getElementById("stat-time").textContent = "Error: " + e.message;
+      }
+      btn.textContent = "⟳ Refresh";
+    }
+
+    function render() {
+      const iconLayer = new deck.IconLayer({
+        id: "vehicles-icon",
+        data,
+        iconAtlas: iconAtlas.url,
+        iconMapping: iconAtlas.mapping,
+        getIcon: d => d.mode || "bus",
+        getPosition: d => d.coordinates,
+        getSize: 40,
+        pickable: true,
+        onHover: handleHover
+      });
+
+      const textLayer = new deck.TextLayer({
+        id: "vehicles-text",
+        data,
+        getPosition: d => d.coordinates,
+        getText: d => d.line_name || "",
+        getSize: 12,
+        getColor: [255, 255, 255, 220],
+        getPixelOffset: [0, -28],
+        fontWeight: "bold",
+        background: true,
+        getBackgroundColor: [30, 30, 60, 200],
+        backgroundPadding: [3, 2, 3, 2],
+        getBorderRadius: 4,
+        pickable: false
+      });
+
+      deckOverlay.setProps({ layers: [iconLayer, textLayer] });
+    }
+
+    function updateHud() {
+      const lines = new Set(data.map(d => d.line_ref).filter(Boolean));
+      document.getElementById("stat-count").textContent = data.length.toLocaleString();
+      document.getElementById("stat-lines").textContent = lines.size.toLocaleString();
+      document.getElementById("stat-time").textContent =
+        "Updated " + new Date().toLocaleTimeString();
+    }
+
+    // --- Tooltip ---
+    const tooltip = document.getElementById("tooltip");
+
+    function handleHover({ object, x, y }) {
+      if (!object) { tooltip.style.display = "none"; return; }
+      const age = object.estimated_at
+        ? formatAge(object.estimated_at)
+        : "unknown";
+      tooltip.innerHTML = `
+        <div class="tline">${object.line_name || object.line_ref || "—"}</div>
+        <div class="trow">Journey: <span>${object.journey_ref || "—"}</span></div>
+        <div class="trow">Line ref: <span>${object.line_ref || "—"}</span></div>
+        <div class="trow">Vehicle ref: <span>${object.vehicle_ref || "—"}</span></div>
+        <div class="trow">Status: <span>${object.status || "—"}</span></div>
+        <div class="trow">Stop name: <span>${object.stop_name || "—"}</span></div>
+        <div class="trow">Next stop name: <span>${object.next_stop_name || "—"}</span></div>
+        <div class="trow">Time estimated: <span>${object.estimated_at || "—"}</span></div>
+        <div class="trow">Progress: <span>${object.progress !== undefined ? object.progress.toFixed(2) : "—"}</span></div>
+        <div class="trow">Updated: <span>${age}</span></div>
+      `;
+      tooltip.style.display = "block";
+      tooltip.style.left = (x + 14) + "px";
+      tooltip.style.top = (y - 10) + "px";
+    }
+
+    function formatAge(isoStr) {
+      const diff = Math.floor((Date.now() - new Date(isoStr)) / 1000);
+      if (diff < 60) return diff + "s ago";
+      if (diff < 3600) return Math.floor(diff / 60) + "m ago";
+      return Math.floor(diff / 3600) + "h ago";
+    }
+
+    // --- Auto refresh ---
+    function toggleAuto() {
+      const btn = document.getElementById("btn-auto");
+      if (autoTimer) {
+        clearInterval(autoTimer);
+        autoTimer = null;
+        btn.textContent = "▶ Auto (3s)";
+        btn.classList.remove("active");
+      } else {
+        autoTimer = setInterval(loadData, REFRESH_INTERVAL);
+        btn.textContent = "⏸ Auto (3s)";
+        btn.classList.add("active");
+        btn.style.background = "";
+      }
+    }
+
+    // --- Init ---
+    map.on("load", loadData);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces a Caddy reverse proxy into the Docker Compose project. 

Key changes:
1.  **Caddy Integration**: A new `caddy` service is added to `docker-compose.yml`. It handles incoming traffic on port 9102.
2.  **Routing**: 
    - The root path (`/`) serves a static HTML tool (`entur_et_interpolate.html`) placed in the `static/` directory.
    - Requests to `/streamlit` are reverse-proxied to the Streamlit service.
3.  **Streamlit Configuration**: Updated `.streamlit/config.toml` with `server.baseUrlPath = "streamlit"` to ensure correct routing and asset loading behind the proxy.
4.  **Security/Structure**: Streamlit's direct port mapping to the host has been removed; it is now only accessible via the Caddy proxy within the Docker network.

This setup prepares the project for future enhancements, such as adding a FastAPI backend or a React frontend.

---
*PR created automatically by Jules for task [10952050037529696750](https://jules.google.com/task/10952050037529696750) started by @knuthp*