### PR TITLE
Vehicle Monitoring Deduplication and Logging

### DIFF
--- a/spartid_pubtransport/api/api.py
+++ b/spartid_pubtransport/api/api.py
@@ -137,8 +137,29 @@ def fetch_and_store_vm():
         df["Latitude"] = df["Latitude"].astype("float64")
         df["Longitude"] = df["Longitude"].astype("float64")
 
+        # Deduplicate for LATEST table
+        pk_cols = ["VehicleRef", "DatedVehicleJourneyRef"]
+        duplicates = df[df.duplicated(subset=pk_cols, keep=False)]
+        if not duplicates.empty:
+            print(f"Duplicates found in VM batch ({len(duplicates)} records):")
+            log_cols = [
+                c
+                for c in pk_cols
+                + ["RecordedAtTime", "LineRef", "VehicleMode", "DataSource"]
+                if c in df.columns
+            ]
+            print(
+                duplicates[log_cols]
+                .sort_values(by=pk_cols + ["RecordedAtTime"])
+                .to_string()
+            )
+
+        df_latest = df.sort_values("RecordedAtTime").drop_duplicates(
+            subset=pk_cols, keep="last"
+        )
+
         with engine.begin() as conn:
-            # 1. Append to history
+            # 1. Append to history (all records)
             df[cols_both].to_sql(
                 name="VEHICLE_MONITORING",
                 con=conn,
@@ -147,8 +168,8 @@ def fetch_and_store_vm():
                 chunksize=1000,
             )
 
-            # 2. Update latest positions
-            df.to_sql("vm_latest_staging", conn, if_exists="replace", index=False)
+            # 2. Update latest positions (deduplicated)
+            df_latest.to_sql("vm_latest_staging", conn, if_exists="replace", index=False)
             conn.execute(
                 text("""
                 INSERT INTO VEHICLE_MONITORING_LATEST (


### PR DESCRIPTION
This change addresses an issue where duplicate primary keys in the Vehicle Monitoring data could cause issues when updating the latest vehicle positions. 

In `fetch_and_store_vm`, we now:
1. Identify records with duplicate `(VehicleRef, DatedVehicleJourneyRef)` within the same fetch batch.
2. Log full details of these duplicates for diagnostic purposes.
3. Deduplicate the batch before updating the `VEHICLE_MONITORING_LATEST` table, ensuring only the most recent update (based on `RecordedAtTime`) is stored.
4. Continue to append all records (including duplicates) to the `VEHICLE_MONITORING` history table as requested.

---
*PR created automatically by Jules for task [12020750917808582209](https://jules.google.com/task/12020750917808582209) started by @knuthp*