### PR TITLE
Visualize vehicle trip shape and stops from GTFS

### DIFF
--- a/spartid_pubtransport/api/api.py
+++ b/spartid_pubtransport/api/api.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import os
 import time
 from pathlib import Path
@@ -8,7 +9,7 @@ import duckdb
 import geopandas
 import pandas as pd
 import sqlalchemy
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from shapely.geometry import Point
@@ -337,6 +338,107 @@ async def get_positions_vm():
         return Response(content=gdf.to_json(), media_type="application/geo+json")
     except Exception as e:
         return {"error": str(e)}
+
+
+@app.get("/api/trip/{trip_id}/details")
+async def get_trip_details(trip_id: str):
+    """
+    Get trip shape and stops as a GeoJSON FeatureCollection.
+    """
+    gtfs_root = Path("data/gtfs/parquet")
+    trips_p = gtfs_root / "trips.parquet"
+    shapes_p = gtfs_root / "shapes.parquet"
+    stop_times_p = gtfs_root / "stop_times.parquet"
+    stops_p = gtfs_root / "stops.parquet"
+
+    if not all(p.exists() for p in [trips_p, shapes_p, stop_times_p, stops_p]):
+        # Try to download if missing
+        try:
+            from spartid_pubtransport.gtfs import GtfsDownloader
+
+            GtfsDownloader().download_and_convert()
+        except Exception as e:
+            raise HTTPException(
+                status_code=503, detail=f"GTFS data not available and download failed: {e}"
+            )
+
+    async with db_lock:
+
+        def query_trip():
+            with duckdb.connect(":memory:") as con:
+                # Find shape_id for the trip
+                res = con.execute(
+                    f"SELECT shape_id FROM read_parquet('{trips_p}') WHERE trip_id = ?",
+                    [trip_id],
+                ).fetchone()
+                if not res:
+                    return None
+
+                shape_id = res[0]
+
+                # Get shape points
+                shape_points = con.execute(
+                    f"""
+                    SELECT shape_pt_lon, shape_pt_lat
+                    FROM read_parquet('{shapes_p}')
+                    WHERE shape_id = ?
+                    ORDER BY shape_pt_sequence
+                    """,
+                    [shape_id],
+                ).fetchall()
+
+                # Get stops
+                stops = con.execute(
+                    f"""
+                    SELECT s.stop_name, s.stop_lon, s.stop_lat, st.stop_sequence
+                    FROM read_parquet('{stop_times_p}') st
+                    JOIN read_parquet('{stops_p}') s ON st.stop_id = s.stop_id
+                    WHERE st.trip_id = ?
+                    ORDER BY st.stop_sequence
+                    """,
+                    [trip_id],
+                ).fetchall()
+
+                return {"shape": shape_points, "stops": stops}
+
+        data = await asyncio.to_thread(query_trip)
+
+    if not data:
+        raise HTTPException(status_code=404, detail="Trip not found")
+
+    features = []
+
+    # Add shape as a LineString
+    if data["shape"]:
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[p[0], p[1]] for p in data["shape"]],
+                },
+                "properties": {"type": "trip_shape", "trip_id": trip_id},
+            }
+        )
+
+    # Add stops as Points
+    for s in data["stops"]:
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [s[1], s[2]]},
+                "properties": {
+                    "type": "trip_stop",
+                    "stop_name": s[0],
+                    "stop_sequence": s[3],
+                },
+            }
+        )
+
+    return Response(
+        content=json.dumps({"type": "FeatureCollection", "features": features}),
+        media_type="application/geo+json",
+    )
 
 
 @app.get("/health")

--- a/spartid_pubtransport/gtfs.py
+++ b/spartid_pubtransport/gtfs.py
@@ -44,9 +44,11 @@ class GtfsDownloader:
         return myzip
 
     def convert_table(self, csv: duckdb.DuckDBPyRelation, parquet_file: Path) -> None:
+        temp_parquet = parquet_file.with_suffix(".tmp.parquet")
         duckdb.sql(
-            f"""COPY(SELECT * FROM csv) TO '{parquet_file}' (FORMAT 'parquet'); """
+            f"""COPY(SELECT * FROM csv) TO '{temp_parquet}' (FORMAT 'parquet'); """
         )
+        temp_parquet.rename(parquet_file)
 
     def download_and_convert(self, table_names: list[str] | None = None) -> None:
         if table_names is None:
@@ -61,7 +63,7 @@ class GtfsDownloader:
                 continue
             csv_file = myzip.extract(f"{table_name}.txt", path=self.gtfs_parquet_root)
             logger.info(f"Extracted {csv_file} from {local_gtfs_zip}")
-            csv = duckdb.read_csv(csv_file)
+            csv = duckdb.read_csv(csv_file, sample_size=-1)
             logger.info(f"Read {csv_file} into DuckDB")
             self.convert_table(csv, parquet_file)
             Path(csv_file).unlink()

--- a/static/index.html
+++ b/static/index.html
@@ -99,6 +99,7 @@
   <script>
     let dataET = [];
     let dataVM = [];
+    let selectedTrip = null;
 
     const ET_GEOJSON_URL = "/api/positions_interpolated.geojson";
     const VM_GEOJSON_URL = "/api/positions_vm.geojson";
@@ -230,6 +231,24 @@
 
     function render() {
       const layers = [
+        new deck.GeoJsonLayer({
+          id: "selected-trip",
+          data: selectedTrip,
+          getLineWidth: 4,
+          getLineColor: [255, 255, 0, 200],
+          getPointRadius: 5,
+          getFillColor: [255, 255, 0, 255],
+          pointRadiusUnits: "pixels",
+          lineWidthUnits: "pixels",
+          pickable: true,
+          onHover: info => {
+            if (info.object && info.object.properties.type === "trip_stop") {
+              handleStopHover(info);
+            } else {
+              handleHover(info);
+            }
+          }
+        }),
         new deck.IconLayer({
           id: "vehicles-et",
           data: dataET,
@@ -239,7 +258,8 @@
           getPosition: d => d.coordinates,
           getSize: 40,
           pickable: true,
-          onHover: handleHover
+          onHover: handleHover,
+          onClick: handleClick
         }),
         new deck.IconLayer({
           id: "vehicles-vm",
@@ -250,7 +270,8 @@
           getPosition: d => d.coordinates,
           getSize: 45,
           pickable: true,
-          onHover: handleHover
+          onHover: handleHover,
+          onClick: handleClick
         }),
         new deck.TextLayer({
           id: "vehicles-text",
@@ -287,8 +308,45 @@
 
     const tooltip = document.getElementById("tooltip");
 
-    function handleHover({ object, x, y }) {
+    async function handleClick({ object }) {
+      if (!object) {
+        selectedTrip = null;
+        render();
+        return;
+      }
+
+      const tripId = object.source === 'VM' ? object.DatedVehicleJourneyRef : object.journey_ref;
+      if (!tripId) return;
+
+      try {
+        const res = await fetch(`/api/trip/${tripId}/details`);
+        if (res.ok) {
+          selectedTrip = await res.json();
+          render();
+        } else {
+          console.error("Failed to fetch trip details:", await res.text());
+        }
+      } catch (e) {
+        console.error("Error fetching trip details:", e);
+      }
+    }
+
+    function handleStopHover({ object, x, y }) {
       if (!object) { tooltip.style.display = "none"; return; }
+      tooltip.innerHTML = `
+        <div class="tline">${object.properties.stop_name}</div>
+        <div class="trow">Sequence: <span>${object.properties.stop_sequence}</span></div>
+      `;
+      tooltip.style.display = "block";
+      tooltip.style.left = (x + 14) + "px";
+      tooltip.style.top = (y - 10) + "px";
+    }
+
+    function handleHover({ object, x, y }) {
+      if (!object || object.properties) { // Skip if it's a GeoJSON feature (unless we want to handle shape hover)
+        if (!object) tooltip.style.display = "none";
+        return;
+      }
 
       const isVM = object.source === 'VM';
       const lineName = isVM ? object.PublishedLineName : object.line_name;
@@ -339,6 +397,10 @@
     }
 
     map.on("load", loadData);
+    map.on("click", () => {
+      selectedTrip = null;
+      render();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This feature allows users to visualize the planned route and stops of any vehicle on the map by clicking on it. 

Key improvements:
- **Backend**: Added a robust endpoint that joins GTFS `trips`, `shapes`, and `stop_times` to generate a GeoJSON FeatureCollection.
- **Frontend**: Integrated vehicle selection state in the deck.gl map, adding a new GeoJSON layer to render the selected trip's path (LineString) and stops (Points) with tooltips.
- **Data Integrity**: Optimized the GTFS conversion process to handle large datasets reliably by disabling DuckDB sampling and using atomic file operations.
- **Verification**: Verified the end-to-end flow using Playwright automation.

---
*PR created automatically by Jules for task [13504513122489642149](https://jules.google.com/task/13504513122489642149) started by @knuthp*